### PR TITLE
Restore IE11 support by using Object.assign polyfill

### DIFF
--- a/addon/components/one-way-credit-card-mask.js
+++ b/addon/components/one-way-credit-card-mask.js
@@ -4,6 +4,7 @@ import OneWayInputMask, {
 import { computed, get, set } from '@ember/object';
 import { isBlank } from '@ember/utils';
 import { scheduleOnce } from '@ember/runloop';
+import { assign } from '@ember/polyfills';
 
 
 /**
@@ -17,7 +18,7 @@ export default OneWayInputMask.extend({
 
     let options = get(this, '_options');
 
-    set(this, '_options', Object.assign({}, {
+    set(this, '_options', assign({}, {
       // We need to make sure we catch paste events so that we change the mask before the text
       // hits the input. This is a callback provided by Inputmask.js
       onBeforePaste: value => {

--- a/addon/components/one-way-date-mask.js
+++ b/addon/components/one-way-date-mask.js
@@ -1,5 +1,6 @@
 import OneWayInputMask from 'ember-inputmask/components/one-way-input-mask';
 import { get, set } from '@ember/object';
+import { assign } from '@ember/polyfills';
 
 const DEFAULT_OPTIONS = {
   inputFormat: 'dd/mm/yyyy',
@@ -19,6 +20,6 @@ export default OneWayInputMask.extend({
   init() {
     this._super(...arguments);
 
-    set(this, '_options', Object.assign({}, get(this, '_options'), DEFAULT_OPTIONS));
+    set(this, '_options', assign({}, get(this, '_options'), DEFAULT_OPTIONS));
   },
 });

--- a/addon/components/one-way-input-mask.js
+++ b/addon/components/one-way-input-mask.js
@@ -3,6 +3,7 @@ import { computed, get, set } from '@ember/object';
 import { schedule } from '@ember/runloop';
 import { areDifferent } from 'ember-inputmask/utils/compare-objects';
 import Inputmask from 'inputmask';
+import { assign } from '@ember/polyfills';
 
 const DEFAULT_OPTIONS = {
   rightAlign: false,
@@ -98,7 +99,7 @@ const OneWayInputMask = Component.extend({
 
     // Give the mask some default options that can be overridden
     let options = get(this, 'options');
-    set(this, '_options', Object.assign({}, DEFAULT_OPTIONS, options));
+    set(this, '_options', assign({}, DEFAULT_OPTIONS, options));
 
     // We want any attribute that is not explicitally blacklisted to be bound that way we don't
     // have to whitelist every single html attribute that an `input` can have. Borrowed from
@@ -133,7 +134,7 @@ const OneWayInputMask = Component.extend({
 
     if (didOptionsChange) {
       // Override external options on top of internal options
-      set(this, '_options', Object.assign({}, get(this, '_options'), options));
+      set(this, '_options', assign({}, get(this, '_options'), options));
     }
 
     // We want to reapply the mask if it has changed

--- a/addon/components/one-way-number-mask.js
+++ b/addon/components/one-way-number-mask.js
@@ -3,6 +3,7 @@ import OneWayInputMask, {
 } from 'ember-inputmask/components/one-way-input-mask';
 import { get, set } from '@ember/object';
 import { isBlank } from '@ember/utils';
+import { assign } from '@ember/polyfills';
 
 const DEFAULT_OPTIONS = {
   groupSeparator: ',',
@@ -25,7 +26,7 @@ export default OneWayInputMask.extend({
 
   /**
    * Set this to true to include decimals
-   * 
+   *
    * @argument decimal
    * @type Boolean
    */
@@ -34,12 +35,12 @@ export default OneWayInputMask.extend({
   init() {
     this._super(...arguments);
 
-    set(this, '_options', Object.assign({}, get(this, '_options'), DEFAULT_OPTIONS));
+    set(this, '_options', assign({}, get(this, '_options'), DEFAULT_OPTIONS));
 
     if (get(this, 'decimal')) {
       set(this, 'mask', 'decimal');
 
-      // Give default digits if we don't have them aleady
+      // Give default digits if we don't have them already
       if (isBlank(get(this, 'options.digits'))) {
         set(this, '_options.digits', 2);
       }

--- a/tests/integration/components/one-way-number-mask-test.js
+++ b/tests/integration/components/one-way-number-mask-test.js
@@ -7,7 +7,7 @@ module('Integration | Component | one way number mask', function(hooks) {
   setupRenderingTest(hooks);
 
   test('It defaults to an integer mask', async function(assert) {
-    this.set('value', 1234.56)
+    this.set('value', 1234.46)
     await render(hbs`{{one-way-number-mask value}}`);
 
     assert.dom('input').hasValue('1,234');


### PR DESCRIPTION
I started noticing errors in our JS error tracker all coming from IE11.

![screen shot 2018-11-16 at 10 05 54](https://user-images.githubusercontent.com/630449/48636123-3abb2480-e987-11e8-88d6-4c55d88c9469.png)

I tracked it own to this plugin and the direct use of `Object.assign`. I've seen this issue before with [Ember Data](https://github.com/emberjs/data/issues/5550) and their solution was to use the `@ember/polyfills` flavor of `assign` instead (see https://github.com/emberjs/data/pull/5549/files).

This PR migrates to use the polyfill. I've confirmed this fix on an [IE11 VM](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/).