### PR TITLE
InputMask Dependency Upgrade

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "ember-cli-babel": "^7.1.2",
     "ember-cli-node-assets": "^0.2.2",
     "fastboot-transform": "^0.1.1",
-    "inputmask": "^4.0.2"
+    "inputmask": "^4.0.9"
   },
   "devDependencies": {
     "@ember/optional-features": "^0.6.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7846,10 +7846,10 @@ inline-source-map-comment@^1.0.5:
     sum-up "^1.0.1"
     xtend "^4.0.0"
 
-inputmask@^4.0.2:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-4.0.4.tgz#a1941b8165e0b1835155d142f873a94b422fbf8d"
-  integrity sha512-m2LAFzQ2IHZbC0FYGP8MO+uVvMGJdTPq07uSzB+v5QF5MOm2h22cAXKxQ4HiOYh3wHwlny9ATuJSp9WPKzq0cg==
+inputmask@^4.0.9:
+  version "4.0.9"
+  resolved "https://registry.yarnpkg.com/inputmask/-/inputmask-4.0.9.tgz#a60fc46cee52a35a0ba5f50b5cca3a6733ece18c"
+  integrity sha512-EodaYhJKncXRBwvCE8YrRmAFmBJ6bWdgX4Qw8QSnK5GBDXE03jgpJhrS+a2N0v2Zsgp+OjKXy7qACktjYD83Uw==
 
 inquirer@^2:
   version "2.0.0"


### PR DESCRIPTION
Upgrading the InputMask underlying dependency. All tests still pass.