### PR TITLE
Use `this.import()` to import JS assets from the `inputmask` package

### DIFF
--- a/addon/components/one-way-input-mask.js
+++ b/addon/components/one-way-input-mask.js
@@ -1,8 +1,9 @@
+/* global Inputmask */
+
 import Component from '@ember/component';
 import { computed, get, set } from '@ember/object';
 import { schedule } from '@ember/runloop';
 import { areDifferent } from 'ember-inputmask/utils/compare-objects';
-import Inputmask from 'inputmask';
 import { assign } from '@ember/polyfills';
 
 const DEFAULT_OPTIONS = {

--- a/index.js
+++ b/index.js
@@ -1,32 +1,22 @@
 'use strict';
 
-const fastbootTransform = require('fastboot-transform');
-
-const filesToImport = [
-  'dependencyLibs/inputmask.dependencyLib.js',
-  'inputmask.js',
-  'inputmask.extensions.js',
-  'inputmask.date.extensions.js',
-  'inputmask.numeric.extensions.js',
-];
 
 module.exports = {
   name: 'ember-inputmask',
-  options: {
-    nodeAssets: {
-      inputmask: () => ({
-        vendor: {
-          include: filesToImport.map(file => `dist/inputmask/${file}`),
-          processTree: input => fastbootTransform(input)
-        }
-      })
-    }
-  },
+
   included() {
-    this._super.included.apply(this, arguments);
-    filesToImport.forEach(file => {
-      this.import(`vendor/inputmask/dist/inputmask/${file}`);
-    });
-    this.import('vendor/shims/inputmask.js');
+    const dependencies = Object.keys(this.project.dependencies());
+    const hasFastboot = dependencies.includes('ember-cli-fastboot');
+
+    const importOptions = {};
+    if (hasFastboot) {
+      importOptions.using = [{ transformation: 'fastbootShim' }];
+    }
+
+    this.import('node_modules/inputmask/dist/inputmask/dependencyLibs/inputmask.dependencyLib.js', importOptions);
+    this.import('node_modules/inputmask/dist/inputmask/inputmask.js', importOptions);
+    this.import('node_modules/inputmask/dist/inputmask/inputmask.extensions.js', importOptions);
+    this.import('node_modules/inputmask/dist/inputmask/inputmask.date.extensions.js', importOptions);
+    this.import('node_modules/inputmask/dist/inputmask/inputmask.numeric.extensions.js', importOptions);
   }
 };

--- a/package.json
+++ b/package.json
@@ -30,8 +30,6 @@
   "dependencies": {
     "ember-cli-babel": "^7.18.0",
     "ember-cli-htmlbars": "^4.2.3",
-    "ember-cli-node-assets": "^0.2.2",
-    "fastboot-transform": "^0.1.1",
     "inputmask": "^4.0.9"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8420,7 +8420,7 @@ fast-sourcemap-concat@^1.4.0:
     source-map-url "^0.3.0"
     sourcemap-validator "^1.1.0"
 
-fastboot-transform@^0.1.1, fastboot-transform@^0.1.3:
+fastboot-transform@^0.1.3:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/fastboot-transform/-/fastboot-transform-0.1.3.tgz#7dea0b117594afd8772baa6c9b0919644e7f7dcd"
   integrity sha512-6otygPIJw1ARp1jJb+6KVO56iKBjhO+5x59RSC9qiZTbZRrv+HZAuP00KD3s+nWMvcFDemtdkugki9DNFTTwCQ==


### PR DESCRIPTION
Using `ember-cli-node-assets` is incompatible with Embroider and can also cause issues when used in a nested addon. Ember CLI has provided an `import()` method for quite some time now, that can take care of a lot of the the same functionality, but is better supported in the edge cases mentioned above.

See also https://github.com/adopted-ember-addons/ember-pikaday/pull/234 for another example of this.