### PR TITLE
CI: Use `yarn` instead of `npm`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,7 @@ addons:
   chrome: stable
 
 cache:
-  directories:
-    - $HOME/.npm
+  yarn: true
 
 env:
   global:
@@ -35,15 +34,15 @@ jobs:
     - stage: "Tests"
       name: "Tests"
       script:
-        - npm run lint
-        - npm run test:ember
+        - yarn lint
+        - yarn test:ember
 
     - stage: "Additional Tests"
       name: "Floating Dependencies"
       install:
-        - npm install --no-package-lock
+        - yarn install --no-lockfile
       script:
-        - npm run test:ember
+        - yarn test:ember
 
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
@@ -54,6 +53,13 @@ jobs:
     - env: EMBER_TRY_SCENARIO=ember-canary
     - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
     - env: EMBER_TRY_SCENARIO=ember-classic
+
+before_install:
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - export PATH=$HOME/.yarn/bin:$PATH
+
+install:
+  - yarn install
 
 script:
   - node_modules/.bin/ember try:one $EMBER_TRY_SCENARIO


### PR DESCRIPTION
Since this project has a `yarn.lock` file I assume that using `yarn` is the preferred way of installing dependencies, and using `npm install` together with `useYarn: true` in the ember-try config can lead to some flaky results.