### PR TITLE
remove computed set deprecation warning

### DIFF
--- a/addon/components/one-way-credit-card-mask.js
+++ b/addon/components/one-way-credit-card-mask.js
@@ -51,11 +51,7 @@ export default OneWayInputMask.extend({
    * @private
    * @return {string} The card type
    */
-  _cardType: computed('_value', {
-    get() {
-      return this._determineCardType(this._value);
-    },
-  }),
+  _cardType: undefined,
 
   /**
    * What kind of separator to use between number sections


### PR DESCRIPTION
Hello!

Thanks for your all your work on this addon, it' great! been using it for quite some time on production. While running our tests, I realized one of the components of the addon was returning this warning.

```
ok 1 Chrome 83.0 - [532 ms] - Integration | Component | one way credit card mask: Visa formatting
    ---
        browser log: |
            WARN: DEPRECATION: The <dummy@component:one-way-credit-card-mask::ember207>#_cardType computed property was just overridden. This removes the computed property and replaces it with a plain value, and has been deprecated. If you want this behavior, consider defining a setter which does it manually. [deprecation id: computed-property.override] See https://emberjs.com/deprecations/v3.x#toc_computed-property-override for more details.
                    at logDeprecationStackTrace (http://localhost:7357/assets/vendor.js:36418:21)
                    at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:36515:9)
                    at raiseOnDeprecation (http://localhost:7357/assets/vendor.js:36445:9)
                    at HANDLERS.<computed> (http://localhost:7357/assets/vendor.js:36515:9)
                    at invoke (http://localhost:7357/assets/vendor.js:36527:9)
                    at deprecate (http://localhost:7357/assets/vendor.js:36483:28)
                    at ComputedProperty.clobberSet (http://localhost:7357/assets/vendor.js:15566:49)
                    at ComputedProperty.set (http://localhost:7357/assets/vendor.js:15534:21)
                    at Class.CPSETTER_FUNCTION [as _cardType] (http://localhost:7357/assets/vendor.js:14495:25)
```

I have been removing these type of deprecations for a while so why not open a PR for it here :)